### PR TITLE
 Add the Hacker News Lists page

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ Hacker News allows users to see what the front page looks like [at any point in 
 
 If you want to gather large amount of Hacker News data for data analysis/machine learning, you should use the [Hacker News dataset on BigQuery](https://cloud.google.com/bigquery/public-data/hacker-news), which is updated daily and is much more pragmatic to use than manually scraping data from the Hacker News API.
 
+### Hacker News Lists
+Hacker News maintains a [list of useful links](https://news.ycombinator.com/lists) that allow for primitive filtering by certain types of content. These currently include:
+
+* [/leaders](https://news.ycombinator.com/leaders)  -- View a list of users with the most karma
+* [/front](https://news.ycombinator.com/front)  -- Filter front page submissions for a given day (e.g. 2016-06-20), ordered by time spent there
+* [/best](https://news.ycombinator.com/best)  -- View the highest-voted recent links
+* [/active](https://news.ycombinator.com/active)  -- View the links with the most active current discussions
+* [/bestcomments](https://news.ycombinator.com/bestcomments)  -- List the highest-voted recent comments
+* [/noobstories](https://news.ycombinator.com/noobstories)  -- Show submissions from new accounts
+* [/noobcomments](https://news.ycombinator.com/noobcomments)  -- List comments from new accounts
+
+
 ## To-Do
 
 * Add more images/citations


### PR DESCRIPTION
I've also mirrored the content in case the source page gets clobbered for whatever reason. The previous pull request (#4) was closed because it would have clobbered another PR that was recently merged.